### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24"]
+        go-version: ["1.26"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Go ${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.24"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -cover -count=1 ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moovfinancial/google-pay-decryptor
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/google/tink/go v1.7.0


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test.yml` to run tests on PRs targeting `main` and pushes to `main`
- Runs `go mod verify`, `go vet`, and `go test -race -cover` on Go 1.24
- Uses matrix strategy for easy addition of future Go versions

## Test plan

- [ ] Merge this PR first, then subsequent PRs (e.g. #9) will have CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)